### PR TITLE
fix: port to current Mach dialect and build system

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "type": "lldb",
       "request": "launch",
       "name": "Debug Mach Executable",
-      "program": "${workspaceFolder}/out/bin/sieve",
+      "program": "${workspaceFolder}/out/linux/bin/sieve",
       "args": [],
       "cwd": "${workspaceFolder}",
       "terminal": "integrated",

--- a/README.md
+++ b/README.md
@@ -8,20 +8,32 @@ This project demonstrates the intended structure of a Mach project, including th
 
 # Building
 
-`cmach` is currently required to build this project. To get `cmach`, clone [https://github.com/octalide/mach](https://github.com/octalide/mach) and follow the instructions to build up to the "cmach" stage (this is as simple as running `make cmach`).
+You need the `mach` compiler. Install the latest [release](https://github.com/octalide/mach/releases) and ensure it is on your `PATH`.
 
-You will then need to ensure that the produced `cmach` binary is in your path.
+The standard library is vendored as a git submodule, so clone with submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/octalide/mach-sieve
+cd mach-sieve
+```
+
+If you already cloned without `--recurse-submodules`, fetch it with:
+
+```bash
+git submodule update --init
+```
 
 To build the project, run:
 
 ```bash
-cmach build .
+mach build .
 ```
 
-This will compile the source files and place the resulting binary in the `out/linux/bin/` directory.
+This compiles the source files and places the resulting binary in `out/linux/bin/sieve`.
 
-You can also run the project after building with:
+You can also build and run in one step. Arguments after `--` are forwarded to the program:
 
 ```bash
-cmach run .
+mach run .            # sieve up to the default limit
+mach run . -- 1000    # sieve up to 1000
 ```

--- a/src/main.mach
+++ b/src/main.mach
@@ -1,28 +1,41 @@
 use std.runtime;
-use std.types.bool;
-use std.types.string;
-use std.types.size;
-use std.types.result;
-use std.types.option;
 
-use alloc: std.allocator;
-use mem:   std.memory;
-use time:  std.time;
-use print: std.print;
-use parse: std.text.parse;
-use vec:   std.collections.vector;
+use alloc:  std.allocator;
+use page:   std.allocator.page;
+use mem:    std.memory;
+use time:   std.chrono.time;
+use dur:    std.chrono.duration;
+use print:  std.print;
+use parse:  std.text.parse;
+use vec:    std.collections.vector;
+use result: std.types.result;
+use option: std.types.option;
 
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.string.str;
+use std.types.size.usize;
+use std.types.option.Option;
+use std.types.result.Result;
+
+# sieve: mark every prime index below limit in primes.
+# ---
+# limit: exclusive upper bound (must be >= 2)
+# primes: buffer of at least count booleans; primes[i] is true iff i is prime
+# count: length of the primes buffer
+# ret: an error message when the inputs are invalid, none otherwise
 fun sieve(limit: u64, primes: *bool, count: usize) Option[str] {
     if (limit < 2) {
-        ret some[str]("limit must be at least 2");
+        ret option.some[str]("limit must be at least 2");
     }
 
     if (primes == nil) {
-        ret some[str]("provided buffer has null data pointer");
+        ret option.some[str]("provided buffer has null data pointer");
     }
 
     if (count < limit::usize) {
-        ret some[str]("provided buffer is smaller than required");
+        ret option.some[str]("provided buffer is smaller than required");
     }
 
     # initialize: assume all are prime
@@ -50,21 +63,21 @@ fun sieve(limit: u64, primes: *bool, count: usize) Option[str] {
         p = p + 2;
     }
 
-    ret none[str]();
+    ret option.none[str]();
 }
 
 $main.symbol = "main";
-fun main(argc: i64, argv: &&u8) i64 {
+fun main(argc: i64, argv: **u8) i64 {
     var limit: u64 = 100000000;
     print.printf("usage: %s [limit] (default: %u)\n", argv[0], limit);
 
     if (argc > 1) {
         val r: Result[u64, str] = parse.parse_u64(argv[1], 10);
-        if (result_is_err[u64, str](r)) {
-            print.printf("error: invalid limit: %s\n", result_unwrap_err[u64, str](r));
+        if (result.is_err[u64, str](r)) {
+            print.printf("error: invalid limit: %s\n", result.unwrap_err[u64, str](r));
             ret 1;
         }
-        limit = result_unwrap_ok[u64, str](r);
+        limit = result.unwrap_ok[u64, str](r);
     }
 
     print.printf("finding primes up to %u\n", limit);
@@ -75,34 +88,41 @@ fun main(argc: i64, argv: &&u8) i64 {
         ret 1;
     }
 
-    # allocate memory for the sieve
-    var a: alloc.Allocator = alloc.default();
-    val r_alloc: Result[*bool, alloc.AllocError] = alloc.allocator_alloc[bool](?a, count);
-    if (result_is_err[*bool, alloc.AllocError](r_alloc)) {
-        print.printf("error: %s\n", result_unwrap_err[*bool, alloc.AllocError](r_alloc));
+    # initialize a page-backed allocator
+    var a: alloc.Allocator;
+    val opt_make: Option[str] = page.make(?a);
+    if (option.is_some[str](opt_make)) {
+        print.printf("error: %s\n", option.unwrap[str](opt_make));
         ret 1;
     }
 
-    val primes: *bool = result_unwrap_ok[*bool, alloc.AllocError](r_alloc);
+    # allocate memory for the sieve
+    val r_alloc: Result[*bool, str] = alloc.allocate[bool](?a, count);
+    if (result.is_err[*bool, str](r_alloc)) {
+        print.printf("error: %s\n", result.unwrap_err[*bool, str](r_alloc));
+        ret 1;
+    }
+
+    val primes: *bool = result.unwrap_ok[*bool, str](r_alloc);
 
     # run the sieve
     val start:   time.Time     = time.now();
     val opt_err: Option[str]   = sieve(limit, primes, count);
-    val elapsed: time.Duration = time.since(start);
+    val elapsed: dur.Duration  = time.since(start);
 
-    if (option_is_some[str](opt_err)) {
-        print.printf("error: %s\n", option_unwrap[str](opt_err));
+    if (option.is_some[str](opt_err)) {
+        print.printf("error: %s\n", option.unwrap[str](opt_err));
         ret 1;
     }
 
     # collect prime indices
-    var indices: vec.Vector[u64] = vec.init[u64](a);
+    var indices: vec.Vector[u64] = vec.init[u64](?a);
     var i: u64 = 0;
     for (i < limit) {
         if (primes[i::usize]) {
-            val r_push: Result[usize, str] = vec.vector_push[u64](?indices, i);
-            if (result_is_err[usize, str](r_push)) {
-                print.printf("error: %s\n", result_unwrap_err[usize, str](r_push));
+            val r_push: Result[usize, str] = vec.push[u64](?indices, i);
+            if (result.is_err[usize, str](r_push)) {
+                print.printf("error: %s\n", result.unwrap_err[usize, str](r_push));
                 ret 1;
             }
         }
@@ -110,7 +130,7 @@ fun main(argc: i64, argv: &&u8) i64 {
     }
 
     print.printf("found:       %u\n", indices.len);
-    print.printf("time taken:  %d ms\n", time.duration_milliseconds(elapsed));
+    print.printf("time taken:  %d ms\n", dur.duration_msec(elapsed));
 
     if (indices.len > 0) {
         print.printf("first prime: %u\n", indices.data[0]);
@@ -118,8 +138,8 @@ fun main(argc: i64, argv: &&u8) i64 {
     }
 
     # cleanup
-    vec.vector_dnit[u64](?indices);
-    alloc.allocator_free[bool](?a, primes, count);
+    vec.dnit[u64](?indices);
+    alloc.deallocate[bool](?a, primes, count);
 
     ret 0;
 }


### PR DESCRIPTION
Closes #5

mach-sieve is the README-advertised standalone starter project but no longer compiled under the locked dialect, and its README still used the removed \`cmach\`/\`make cmach\` flow. This ports it to current Mach + mach-std and rewrites the build docs.

## Changes

- **\`src/main.mach\`** — ported to the current dialect and std API:
  - \`main(argc: i64, argv: **u8)\` (was \`&&u8\`)
  - allocator: \`page.make(?a)\` + \`allocate[T]\`/\`deallocate[T]\` returning \`Result[*T, str]\` (was \`alloc.default()\` + \`allocator_alloc\`/\`allocator_free\` with \`AllocError\`)
  - result/option: module-qualified \`result.is_err\`/\`result.unwrap_*\`/\`option.is_some\`/\`option.unwrap\` (was free functions like \`result_is_err[..]\`)
  - vector: \`vec.init\`/\`vec.push\`/\`vec.dnit\` (was \`vector_push\`/\`vector_dnit\`)
  - timing: \`std.chrono.time\` + \`std.chrono.duration.duration_msec\` (was \`std.time\` + \`duration_milliseconds\`)
  - kept \`use std.runtime;\` (required to link \`_start\`)
- **\`dep/mach-std\`** — bumped submodule to current dev.
- **\`README.md\`** — install a mach release binary, clone with submodules, \`mach build .\` / \`mach run .\` (removed all \`cmach\`).
- **\`.vscode/launch.json\`** — corrected debug binary path to \`out/linux/bin/sieve\`.

## Verification (mach v1.0.0)

\`mach build .\` succeeds from a clean tree; the prime sieve runs correctly:

| limit | primes found | last prime |
|---|---|---|
| 100 | 25 | 97 |
| 1,000,000 | 78,498 | 999,983 |
| 100,000,000 (default) | 5,761,455 | 99,999,989 |

Edge cases verified: \`limit 1\` -> "limit must be at least 2", non-numeric arg -> "invalid digit".